### PR TITLE
Remove Region Check for Pipeline

### DIFF
--- a/src/foremast/pipeline/create_pipeline.py
+++ b/src/foremast/pipeline/create_pipeline.py
@@ -184,7 +184,7 @@ class SpinnakerPipeline:
         pipelines = self.get_existing_pipelines()
         pipeline_id = None
         for pipeline in pipelines:
-            if (pipeline['application'] == self.app_name) and (region in pipeline['name']):
+            if (pipeline['application'] == self.app_name):
                 self.log.info('Existing pipeline found - %s', pipeline['name'])
                 pipeline_id = pipeline['id']
                 break


### PR DESCRIPTION
Problem:
Currently Foremast only considers pipelines with the region name appended to the end as a managed pipeline. We do not need to have the region appended to our pipeline names since we only operate out of one region for now.

Solution:
Remove the region check and let foremast go on its marry way.